### PR TITLE
Fix root URL redirection to default locale (/en) instead of just 404ing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,9 @@ import {defineConfig} from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+  redirects: {
+    '/': '/en', // Prevents 404's on root domain.
+  },
   integrations: [
     starlight({
       title: 'The HyDE project',


### PR DESCRIPTION
## Issue

When accessing the root URL ([https://hydeproject.pages.dev](https://hydeproject.pages.dev/)), the site returns a `404 Page not found` error instead of redirecting to the default locale (`/en`), which contains some content. 

This behavior currently prevents users from accessing the default content directly from the root URL.

## Solution

To address this issue, a quick redirection has been added to ensure that accessing the root URL (https://hydeproject.pages.dev/) automatically redirects users to the default locale (/en). 

## More

While the ideal solution would maybe be to configure the site to remove the `/en/` prefix entirely (similar to options available in Astro/i18n modules), this quick fix aims to restore immediate access to the site content. 

We'll figure it out with more work on #8 #9. :) 