### PR TITLE
fix redirection on english home page

### DIFF
--- a/src/content/docs/en/help/faq.md
+++ b/src/content/docs/en/help/faq.md
@@ -142,7 +142,7 @@ if you want to modify the structure then you'll have to modify the qml files in 
 
 Read this first: https://wiki.hyprland.org/Configuring/Variables/#input
 
-In HyDE we have the `~/.config/hypr/userprefs.conf ` add the configuration in there.
+In HyDE we have the `~/.config/hypr/userprefs.conf` add the configuration in there.
 
 ```
 input {
@@ -159,7 +159,7 @@ Use `SUPER` + `K` to switch between layouts.
 <details>
 <summary>〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️</summary>
 
-If your thumnails are not loading, try to rebuild your wallpaper cache.
+If your thumbnails are not loading, try to rebuild your wallpaper cache.
 
 `swwwallcache.sh`
 

--- a/src/content/docs/en/index.mdx
+++ b/src/content/docs/en/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../../assets/hyde.svg
   actions:
     - text: Get Started with HyDE
-      link: ./en/getting-started/introduction
+      link: ../en/getting-started/introduction
       icon: rocket
     - text: Explore on GitHub
       link: https://github.com/HyDE-Project

--- a/src/content/docs/en/index.mdx
+++ b/src/content/docs/en/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../../assets/hyde.svg
   actions:
     - text: Get Started with HyDE
-      link: ../en/getting-started/introduction
+      link: ./en/getting-started/introduction
       icon: rocket
     - text: Explore on GitHub
       link: https://github.com/HyDE-Project


### PR DESCRIPTION
the redirection when clicking on the "Getting started with HyDE" button broke on the english homepage

when you visit the website, normally you get to https://hydeproject.pages.dev/
but by clicking on the top-left logo, or by changing to another language and then going back to english, you get to https://hydeproject.pages.dev/en/

The homepage button "Getting started with HyDE" then instead redirects to

> https://hydeproject.pages.dev/en/en/getting-started/introduction 

instead of

> https://hydeproject.pages.dev/en/getting-started/introduction

i looked at the other languages homepages and they seem to go back one directory to then get to the docs instead of going in the current directory like english, which ultimately leads to the misredirection.

<sub><sup>this is my first pull request ever so sorry if i am wrong</sup></sub>