### PR TITLE
docs: Fix typos and improve consistency

### DIFF
--- a/src/content/docs/en/configuring/hyprland.md
+++ b/src/content/docs/en/configuring/hyprland.md
@@ -78,9 +78,9 @@ Since Hyprland sources `~/.config/hypr/hyprland.conf`, HyDE's hyprland configura
 
 This section contains the default configuration of HyDE. It is recommended not to change this section.
 
-**Filepath:** $XDG_DATA_HOME/hyde/hyprland.conf`
+**Filepath:** `$XDG_DATA_HOME/hyde/hyprland.conf`
 
-This file is sourced on top of other configurations in ~/.config/hypr/hyprland.conf`.
+This file is sourced on top of other configurations in `~/.config/hypr/hyprland.conf`.
 
 ```ini
 # Boilerplate configuration
@@ -105,7 +105,7 @@ To unset a variable, leave it blank
 
 :::
 
-**Filepath:** $XDG_CONFIG_HOME/hypr/hyde.conf`
+**Filepath:** `$XDG_CONFIG_HOME/hypr/hyde.conf`
 
 ### HyDE Configuration Variables
 
@@ -133,7 +133,7 @@ To unset a variable, leave it blank
 | $FONT_ANTIALIASING   | Font antialiasing           | rgba                         |
 | $FONT_HINTING        | Font hinting                | full                         |
 
-### Startup Commands ($start.\*`)
+### Startup Commands (`$start.\*`)
 
 The default commands on startup.
 
@@ -154,7 +154,7 @@ The default commands on startup.
 | $start.AUTH_DIALOGUE        | Starts the authentication dialogue script                    | $scrPath/polkitkdeauth.sh                                                                    |
 | $start.IDLE_DAEMON          | Starts the idle daemon                                       | $IDLE                                                                                        |
 
-### Environment Variables ($env.\*`)
+### Environment Variables (`$env.\*`)
 
 | Variable                                 | Description                                    | Default Value                 |
 | ---------------------------------------- | ---------------------------------------------- | ----------------------------- |
@@ -192,10 +192,10 @@ This section is for user configuration. It is recommended to change this section
 
 **Filepaths:**
 
-- ./keybindings.conf`
-- ./windowrules.conf`
-- ./monitors.conf`
-- ./userprefs.conf`
+- `./keybindings.conf`
+- `./windowrules.conf`
+- `./monitors.conf`
+- `./userprefs.conf`
 
 ---
 
@@ -210,4 +210,4 @@ Also Hyprland can hot reload the configuration files, so you can edit them and s
 
 Now you should know which file is which. Refer to the [Hyprland Wiki](https://wiki.hyprland.org) for more information and to achieve your perfect desktop experience.
 
-Also see[FAQs and Tips](../help/faq#how-can-i-change-keyboard-layout)
+Also see [FAQs and Tips](../help/faq#how-can-i-change-keyboard-layout).

--- a/src/content/docs/en/getting-started/installation.md
+++ b/src/content/docs/en/getting-started/installation.md
@@ -11,7 +11,8 @@ For Nixos support there is a separate project being maintained @ [Hydenix](https
 :::note
 
 The install script will auto-detect an NVIDIA card and install nvidia-dkms drivers for your kernel.
-Please ensure that your NVIDIA card supports dkms drivers in the list provided [here](https://wiki.archlinux.org/title/NVIDIA). Fancy stuff here
+Please ensure that your NVIDIA card supports dkms drivers in the list provided [here](https://wiki.archlinux.org/title/NVIDIA).
+:::
 
 :::danger
 
@@ -77,7 +78,7 @@ The install script can be executed in different modes,
 ./install.sh -i pkg_user.lst # minimal install pkg_core.lst + pkg_user.lst without configs
 ```
 
-- each[section](#process) can also be independently executed as,
+- each [section](#process) can also be independently executed as,
 
 ```shell
 ./install.sh -i # minimal install hyprland without any configs

--- a/src/content/docs/en/getting-started/installation.md
+++ b/src/content/docs/en/getting-started/installation.md
@@ -51,9 +51,9 @@ or you can `cp  Scripts/pkg_extra.lst Scripts/pkg_user.lst` if you wish to insta
 
 Clone the repo and change the directory to the script path. Then make sure the user has [w]rite and e[x]ecute permission to the clone directory
 
-```sh
+```shell
 pacman -Sy git
-git clone --depth 1 https://github.com/prasanthrangan/hyprdots ~/HyDE
+git clone --depth 1 https://github.com/HyDE-Project/HyDE ~/HyDE
 cd ~/HyDE/Scripts
 ```
 

--- a/src/content/docs/en/help/faq.md
+++ b/src/content/docs/en/help/faq.md
@@ -46,9 +46,7 @@ Custom wallpapers are added per theme.
 1. Add a wallpaper in`~/.config/hyde/themes/Theme-Name/wallpapers/*`.
 2. Then run`hyde-shell reload`
 
----
 
----
 
 </details>
 
@@ -100,11 +98,12 @@ See `Resources` > `Restore Configuration` on how it works
 <details>
 <summary>〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️</summary>
 
+Read this for details: https://wiki.hyprland.org/Configuring/Monitors/
+
 You can set the monitor resolution and refresh rate in `~/.config/hypr/monitors.conf`
 
-`monitor = DP-1,2560x1440@144,0x0, 1` >> The @ set's the refresh rate
+Ex: `monitor = DP-1,2560x1440@144,0x0, 1` >> The @ set's the refresh rate, but note that your monitor may not support all refresh rates.
 
-This is a `how to hyprland` question, always seek there wiki, https://wiki.hyprland.org/Configuring/Monitors/
 
 </details>
 
@@ -115,9 +114,9 @@ This is a `how to hyprland` question, always seek there wiki, https://wiki.hyprl
 
 You need to edit the `.hyde.zshrc` file in your home directory at `~/.hyde.zshrc`
 
-1. Edit`~/.hyde.zshrc`
-2. add a # to line 158 where pokego --no-title -r 1,3,6
-3. save
+1. Edit `~/.hyde.zshrc`
+2. Add a # to line 158 where it writes `pokego --no-title -r 1,3,6`
+3. Save
 
 </details>
 
@@ -140,7 +139,7 @@ if you want to modify the structure then you'll have to modify the qml files in 
 <details>
 <summary>〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️</summary>
 
-Read this first: https://wiki.hyprland.org/Configuring/Variables/#input
+Read this for details: https://wiki.hyprland.org/Configuring/Variables/#input
 
 In HyDE we have the `~/.config/hypr/userprefs.conf` add the configuration in there.
 
@@ -172,7 +171,7 @@ If your thumbnails are not loading, try to rebuild your wallpaper cache.
 
 You can set your required modules in this file - `~/.config/waybar/config.ctl`
 
-Refer to the theming documentation here in the Wiki. [Waybar](https://github.com/Alexays/Waybar/wiki)
+Refer to the theming documentation in the [Waybar Wiki](https://github.com/Alexays/Waybar/wiki).
 
 </details>
 
@@ -207,7 +206,9 @@ You should copy then edit the .desktop entry of each application to `~/.local/sh
 Find the Exec = part then add the flags
 image
 
-> 📢 Remember, if you're looking to edit or create a .desktop file, it's a good practice to place it in ~/.local/share/applications/ to avoid modifying >system-wide files. This ensures that your changes are user-specific and do not require administrative privileges
+:::note
+📢 Remember, if you're looking to edit or create a .desktop file, it's a good practice to place it in ~/.local/share/applications/ to avoid modifying >system-wide files. This ensures that your changes are user-specific and do not require administrative privileges
+:::
 
 Here is the [wiki](https://wiki.archlinux.org/title/Desktop_entries) on how to deal with .desktop entries.
 
@@ -218,7 +219,7 @@ Here is the [wiki](https://wiki.archlinux.org/title/Desktop_entries) on how to d
 <details>
 <summary>〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️〰️</summary>
 
-Please navigate to the Hyprland wiki for the explanation.
+Please refer to the [Hyprland Wiki](https://wiki.hyprland.org) for the explanation.
 
 [XWayland](https://wiki.hyprland.org/Configuring/XWayland/)
 Note that if the application does not support Wayland, HyDE, Hyprland and Wayland itself don't have powers to magically fixed the issue! Do not report this as an issue, try to open questions on the [Discussion panel](https://github.com/HyDE-Project/Hyde-cli) for help.

--- a/src/content/docs/en/index.mdx
+++ b/src/content/docs/en/index.mdx
@@ -28,10 +28,10 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     Follows the XDG Base Directory Specification.
   </Card>
   <Card title="Easier core updates" icon="add-document">
-    Core scripts are separated to user config
+    Core scripts are separated to user config.
   </Card>
   <Card title="More Themes!" icon="moon">
-	More theming options
+	More theming options.
 </Card>
   <Card title="Modular!" icon="puzzle">
 	One of the directions of this project is to be modular.

--- a/src/content/docs/en/man-pages/overview.md
+++ b/src/content/docs/en/man-pages/overview.md
@@ -5,4 +5,4 @@ sidebar:
   order: 1
 ---
 
-HyDE manuals for scripts and executables
+HyDE manuals for scripts and executables.

--- a/src/content/docs/en/resources/restore.md
+++ b/src/content/docs/en/resources/restore.md
@@ -5,7 +5,7 @@ description: Restore script's logic
 
 :::note
 
-> "restore" in further context is restoring the dotfiles from the repository to your $HOME, not the other way around.
+"restore" in further context is restoring the dotfiles from the repository to your $HOME, not the other way around.
 
 ```sh
 ./restore_cfg.sh </path/to/file.psv > <optional /path/to/hyde/clone>

--- a/src/content/docs/en/theming/wallbash-and-dcol.md
+++ b/src/content/docs/en/theming/wallbash-and-dcol.md
@@ -45,7 +45,9 @@ A template requires three parts:
 
 ---
 
-> **Note:** **target**|**command** should always be on line 1 of every template file. We will call it `header line`.
+:::note
+**target**|**command** should always be on line 1 of every template file. We will call it `header line`.
+:::
 
 #### Target File
 
@@ -63,7 +65,9 @@ Use environment variables to handle directories dynamically:
 
 After filling the target file with contents, you can run arbitrary commands/scripts for post-processing. Use the `WALLBASH_SCRIPTS` variable to navigate to Wallbash's script directory, e.g., `WALLBASH_SCRIPTS/your_script.sh`.
 
-> **Caution:** Only add templates from trusted authors to avoid executing bad code.
+:::caution 
+Only add templates from trusted authors to avoid executing bad code.
+:::
 
 #### Contents
 

--- a/src/content/docs/en/theming/wallbash-and-dcol.md
+++ b/src/content/docs/en/theming/wallbash-and-dcol.md
@@ -39,11 +39,11 @@ A template requires three parts:
 
 ## The basic format:
 
-| target       | command |
-| ------------ | ------- |
-| **contents** |
+```
+target|command 
+contents
+```
 
----
 
 :::note
 **target**|**command** should always be on line 1 of every template file. We will call it `header line`.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -28,10 +28,10 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     Follows the XDG Base Directory Specification.
   </Card>
   <Card title="Easier core updates" icon="add-document">
-    Core scripts are separated to user config
+    Core scripts are separated to user config.
   </Card>
   <Card title="More Themes!" icon="moon">
-	More theming options
+	More theming options.
 </Card>
   <Card title="Modular!" icon="puzzle">
 	One of the directions of this project is to be modular.


### PR DESCRIPTION
Lots of small changes to hopefully make the docs better.
I have two questions:
1. In `Wallbash and dcol > The basic format:`, there's just a grid. I assume it shouldn't be that way.
2. `prasanthrangan/hyprdots` appears in `Installation > Granular and Manual Installation`. Is that on purpose?

I'll revert changes if the original phrasing is deemed better, thanks for your time :D