### PR TITLE
Fixing the FAQ mistake

### DIFF
--- a/src/content/docs/en/help/faq.md
+++ b/src/content/docs/en/help/faq.md
@@ -122,6 +122,7 @@ Uninstall pokego-bin.
 Edit `~/.config/zsh/user.zsh`
 
 </div>
+</details>
 
 <details>
 <summary id="sddm-settings">How do I edit the sddm wallpaper or settings?</summary>


### PR DESCRIPTION
Added missing closing detail tag that caused the rest of the questions to be a child of the terminal startup intro question.  Sorry about that.  I will make sure I am testing the site before pushing in the future.