### PR TITLE
docs: Introduce lua help article and migration notices.

### DIFF
--- a/src/content/docs/en/help/lua.md
+++ b/src/content/docs/en/help/lua.md
@@ -62,18 +62,18 @@ hyde-shell layouts --select
 | Window rules | `~/.config/hypr/windowrules.conf` | `/.local/share/hypr/lua/window_rules.lua` but preferably you'd port them into `hyprland.lua` |
 | Startup settings | `[hyprland-start]` in `config.toml` | `[desktop.start]` in `$XDG_DATA_HOME/hyde/config-registry.toml` |
 | UserPrefs | `.config/hypr/userprefs.conf` | `~/.local/share/hypr/lua/defaults.lua` |
-| backup-restore | [legacy restore lists](../resources/restore.md) | [`deez` manifests invoked by `install.sh -r`](../resources/restore.md##tomlConfiguration) |
+| backup-restore | [legacy restore lists](../resources/restore.md) | [`deez` manifests invoked by `install.sh -r`](../resources/restore.md#tomlConfiguration) |
 
 :::tip[HyDE+Lua brings a whole new module boundary]
 If you're used to editing conf files due to glitchy themeing or mistimed updates then you'll love the new rigidness of Lua, and if you've never had to deal with that then consider it a perfect time to jump in and make HyDE better.
 :::
 
-Lua prevents a lot of the one-off tricks we started to rely on in-order to make hyprlang work for finer routines,
+Lua prevents a lot of the one-off tricks we started to rely on in order to make hyprlang work for finer routines,
 but it is **not** a guaranteed performance upgrade. Its main benefit is a more maintainable configuration and long-term support. The following table takes into account 'changes' as the differences between the latest available dev branch and a 'stable' release from before May 12th 2026 [95adf01]:
 
-| Files changed | |LOC changes | Scripts | Description |
+| Files changed | | LOC changes | Scripts | Description |
 | --- | --- | --- | --- |
-| 44 | +2,074 | −159 | 33 added, 11 modified, 29 unchanged | Adds dotfile manifests and migrations; updates installation and restore support. |
+| 44 | +2,074, −159 | 33 added, 11 modified, 29 unchanged | Adds dotfile manifests and migrations; updates installation and restore support. |
 
 the new `dots` and `dots-groups` folders in ~/HyDE/Scripts/ containing the dot-file schemas.
 
@@ -90,7 +90,7 @@ All previous entrypoints have been updated;
 ---
 
 :::danger
-Don't mess with TOML or Lua data you don't recognize, the punishment for running a broken dot-file setup is much bigger, as is our ability to build out HyDE. $XDG_DATA_HOME/hypr/lua/* defines a lot of what happends after uwsm launches and mounts HyDE's drop-in configuration and is at the heart of HyDE's functionality.
+Don't mess with TOML or Lua data you don't recognize, the punishment for running a broken dot-file setup is much bigger, as is our ability to build out HyDE. $XDG_DATA_HOME/hypr/lua/* defines a lot of what happens after uwsm launches and mounts HyDE's drop-in configuration and is at the heart of HyDE's functionality.
 :::
 
 ### Runtime upgrades
@@ -113,7 +113,7 @@ Files below `~/.local/share/hypr/lua/` and `~/.local/share/hypr/hyde.lua` are de
 
 ## Hyprlang to Lua
 
-**Hyprlang files are declarative**: they describe settings and dispatch commands. What's inside a .conf file was a lie, it was and will always tend to be `Hypr` compliant syntax. Lua can express the same settings, then add functions, event handlers, and shared helpers where they make sense; which some conf files were doing anyways.
+**Hyprlang files are declarative**: they describe settings and dispatch commands. What's inside a .conf file was a lie, it was and will always tend to be `Hypr` compliant syntax. Lua can express the same settings, then add functions, event handlers, and shared helpers where they make sense; which some conf files were doing anyway.
 
 For example, a legacy input block such as:
 
@@ -210,8 +210,8 @@ For an intentionally controlled retry, use the same command shape as the install
 ```
 
 **Replace the `--list` flag for `--deploy all` only if you're sure it won't cause conflicts**
-If it does, please don't report on it. As mentioned `deez-dots` its an _implementation detail_,
-it's very practical outside our context but within, has been harnessed down so that there's very litte
+If it does, please don't report on it. As mentioned `deez-dots` is an _implementation detail_,
+it's very practical outside our context but within, has been harnessed down so that there's very little
 risk of it failing outside user error.
 
 :::tip[Use the full installer]
@@ -234,8 +234,8 @@ Run `./install.sh -p` to establish environment setup according to the newest git
 
 1. Review [Installation](../../getting-started/installation/) and clone the Lua-enabled HyDE revision you intend to use.
 2. Make a smart backup. I recommend: `~/.config/hypr`, `~/.config/hyde`, `~/.config/dconf`, `~/.config/gtk-3.0`, `~/.config/qt5ct`, `~/.config/qt6ct`, `~/.config/kdeglobals`, `~/.gtkrc-2.0`, and `~/.config/uwsm`.
-3. Definetly make sure `luarocks` and the preface is set-up: `./install.sh -p`. Running `./install.sh -r` will not and **can not** translsate or transfer your existing .conf syntax into usable HyDE+Lua syntax.
-4. Port legacy Hyprlang customisations into the directoris described throughout this doc. ($XDG_DATA_HOME, $HYPRLAND_CONFIG, $UWSM_FINALIZE_VARNAMES)
+3. Definitely make sure `luarocks` and the preface is set-up: `./install.sh -p`. Running `./install.sh -r` will not and **can not** translate or transfer your existing .conf syntax into usable HyDE+Lua syntax.
+4. Port legacy Hyprlang customisations into the directories described throughout this doc. ($XDG_DATA_HOME, $HYPRLAND_CONFIG, $UWSM_FINALIZE_VARNAMES)
 5. Start a new HyDE session(should happen automatically), then verify the runtime and reload Hyprland:
 
 ```bash

--- a/src/content/docs/en/help/lua.md
+++ b/src/content/docs/en/help/lua.md
@@ -1,8 +1,6 @@
 ---
 title: Lua for the User & Migration
 description: How HyDE's Lua-based Hyprland runtime is deployed, configured, and migrated from the legacy Hyprlang layout.
-sidebar:
-order: 4
 ---
 
 This document explains the Lua-based Hyprland stack introduced by [the Lua migration](https://github.com/HyDE-Project/HyDE/discussions/1717). It is written for existing HyDE users deciding whether, and how, to move from the legacy Hyprlang configuration.
@@ -20,7 +18,7 @@ Essentially, we're migrating to something with better support, **Lua**. Quite th
 
 Hyprlang was the old material we used to carry important environment variables and its functionality was limited. Here's an example taken from the old startup.conf:
 
-```conf
+```sh
 exec-once = dbus-update-activation-environment --systemd --all #? Might fail so we hardcode the variables below
 exec-once = $start.DBUS_SHARE_PICKER    # dbus-update-activation-environment (one-time setup)
 exec-once = $start.SYSTEMD_SHARE_PICKER # systemctl --user import-environment (one-time setup)

--- a/src/content/docs/en/help/lua.md
+++ b/src/content/docs/en/help/lua.md
@@ -1,0 +1,251 @@
+---
+title: Lua for the User & Migration
+description: How HyDE's Lua-based Hyprland runtime is deployed, configured, and migrated from the legacy Hyprlang layout.
+sidebar:
+  order: 4
+---
+
+This document explains the Lua-based Hyprland stack introduced by [the Lua migration](https://github.com/HyDE-Project/HyDE/discussions/1717). It is written for existing HyDE users deciding whether, and how, to move from the legacy Hyprlang configuration.
+
+:::caution[Migration-era documentation]
+The Lua migration changes and removes dot-files, and whole directories. Back up your Hyprland and HyDE configuration before restoring Lua dotfiles only if you have edited the `.local/lib` `.local/share` `.local/state` `.config/` HyDE dirs (drop-ins should survive.) The current [Hyprland configuration](../../configuring/hyprland/) article documents the legacy `.conf` layout; use this page as the companion migration reference until that article is updated.
+:::
+
+## At a glance 👁️‍🗨️
+
+HyDE is not replacing every configuration format with Lua. Nor are we forcing a refactor of every script and component.
+It is mostly about longevity, sealing down the **Hyprland runtime** from a Hyprlang `.conf` tree  into something stable.
+Also, the addition of Lua modules and retaining TOML for declarative HyDE settings and dotfile manifests are natural fits.
+Essentially, we're migrating to something with better support, **Lua**. Quite the popular scripting and systems language, among other tasks it creates variables like `hl`, `start`, `hyde`, `hs` etc. This is a core upgrade:
+
+Hyprlang was the old material we used to carry important environment variables and its functionality was limited. Here's an example taken from the old startup.conf:
+
+```conf
+exec-once = dbus-update-activation-environment --systemd --all #? Might fail so we hardcode the variables below
+exec-once = $start.DBUS_SHARE_PICKER    # dbus-update-activation-environment (one-time setup)
+exec-once = $start.SYSTEMD_SHARE_PICKER # systemctl --user import-environment (one-time setup)
+exec-once = $start.XDG_PORTAL_RESET     # resetxdgportal.sh (one-time setup)
+```
+
+As you can see the infrastructure was always somewhat unbalanced about the long-term viability. Simply put,
+Hyprlang was good for having a table of variables, not for moving parts like is required for runtime operations.
+
+``` lua [.local/share/hypr/lua/start_up.lua]
+    hl.on(
+            "hyprland.start",
+            function()
+                check_exec(hs.dbus_share_picker)
+                check_exec(hs.systemd_share_picker)
+                check_exec(hs.auth_dialogue)
+    )
+```
+
+Instead of hoping that `startup.conf` goes off before hyprland starts, we declare an event `hyprland.start` or `hyde.activate` which chains into runtime operation, `hyde-shell reload` shows this off as it rebuilds core environments.
+
+## Layouts
+
+Layouts is a new and exclusive lua feature that allows the user to change the behaviour of their whole WM in 1 swift action,
+keybinds, transitions inbetween workplaces, and windows among just the general _feel_ of your computer.
+The default workflow and layout settings are unset, meaning that something else has to launch them.
+
+Choose a layout:
+
+```sh
+hyde-shell layouts --select
+```
+
+### Notable files & concerns
+
+| Concern | Legacy setup | Lua setup |
+| --- | --- | --- |
+| Hyprland entrypoint | `~/.config/hypr/hyprland.conf` or `$XDG_DATA_HOME/hyprland.conf` | `$XDG_DATA_HOME/hypr/hyde.lua` and `~/.config/hypr/hyprland.lua` |
+| Window rules | `~/.config/hypr/windowrules.conf` | `/.local/share/hypr/lua/window_rules.lua` but preferably you'd port them into `hyprland.lua` |
+| Startup settings | `[hyprland-start]` in `config.toml` | `[desktop.start]` in `$XDG_DATA_HOME/hyde/config-registry.toml` |
+| UserPrefs | `.config/hypr/userprefs.conf` | `~/.local/share/hypr/lua/defaults.lua` |
+| backup-restore | [legacy restore lists](../resources/restore.md) | [`deez` manifests invoked by `install.sh -r`](../resources/restore.md##tomlConfiguration) |
+
+:::tip[HyDE+Lua brings a whole new module boundary]
+If you're used to editing conf files due to glitchy themeing or mistimed updates then you'll love the new rigidness of Lua, and if you've never had to deal with that then consider it a perfect time to jump in and make HyDE better.
+:::
+
+Lua prevents a lot of the one-off tricks we started to rely on in-order to make hyprlang work for finer routines,
+but it is **not** a guaranteed performance upgrade. Its main benefit is a more maintainable configuration and long-term support. The following table takes into account 'changes' as the differences between the latest available dev branch and a 'stable' release from before May 12th 2026 [95adf01]:
+
+| Files changed | |LOC changes | Scripts | Description |
+| --- | --- | --- | --- |
+| 44 | +2,074 | −159 | 33 added, 11 modified, 29 unchanged | Adds dotfile manifests and migrations; updates installation and restore support. |
+
+the new `dots` and `dots-groups` folders in ~/HyDE/Scripts/ containing the dot-file schemas.
+
+`Helper functions` for `install.sh` which are supposed to make migrating more simple and reinforces the python env
+_~/HyDE/Scripts/dots/hyprland.toml_ deploys the Lua tree.
+
+All previous entrypoints have been updated;
+
+| Entrypoint | Description |
+| --- | --- |
+| $XDG_DATA_HOME/.local/share/hypr/hyde.lua | Rewards promises to the environment such as the runtime environment, core lua scripts, all `.config/` userprefs and `.local/` fallbacks |
+| $XDG_CONFIG_HOME/hypr/hyprland.lua | User override layer or simply 'user preferences' is part of the desired zone for interfacing with this upgrade, from adding keybinds to summoning HyDE scripts with lua. The `require("")`directive is helpful |
+
+---
+
+:::danger
+Don't mess with TOML or Lua data you don't recognize, the punishment for running a broken dot-file setup is much bigger, as is our ability to build out HyDE. $XDG_DATA_HOME/hypr/lua/* defines a lot of what happends after uwsm launches and mounts HyDE's drop-in configuration and is at the heart of HyDE's functionality.
+:::
+
+### Runtime upgrades
+
+Since lua is now parrallel in terms to our python environment. HyDE activates the Lua stack through UWSM:
+
+```text
+UWSM environment scripts
+  -> ~/.local/lib/hyde/shell/activate
+  -> HYDE_MODE=lua and HYPRLAND_CONFIG=.../hypr/hyde.lua
+  -> Hyprland loads hyde.lua
+  -> HyDE loads its Lua modules and ~/.config/hypr/hyprland.lua
+```
+
+The shared runtime belongs under `$XDG_DATA_HOME/hypr/`; your user changes belong under `$XDG_CONFIG_HOME/hypr/`. This follows HyDE's usual separation between maintained data and user-owned configuration. See [Secrets & Portals](../secrets/) for the related UWSM and XDG session model.
+
+:::note[Do not edit the shared runtime for no reason]
+Files below `~/.local/share/hypr/lua/` and `~/.local/share/hypr/hyde.lua` are deployed by HyDE and can change on restore. Branch out by placing direct overrides in `~/.config/hypr/hyprland.lua`, and split larger customisations into Lua files that can be loaded retroactively with `require()`.
+:::
+
+## Hyprlang to Lua
+
+**Hyprlang files are declarative**: they describe settings and dispatch commands. What's inside a .conf file was a lie, it was and will always tend to be `Hypr` compliant syntax. Lua can express the same settings, then add functions, event handlers, and shared helpers where they make sense; which some conf files were doing anyways.
+
+For example, a legacy input block such as:
+
+```ini
+# ~/.config/hypr/userprefs.conf
+input {
+    kb_layout = us,es
+    accel_profile = flat
+}
+```
+
+becomes a more meaningful profile:
+
+```lua
+# ~/.config/hypr/hyprland.lua
+hl.config({
+    input = {
+        kb_layout = "us,es",
+        accel_profile = "flat",
+    },
+})
+```
+
+Likewise, a key binding can use HyDE's Lua helpers instead of a comma-delimited `bind` line:
+
+```lua
+hl.bind(
+    "SUPER + Q",
+    hl.dsp.window.close(),
+    { description = "[Window Management] close focused window" }
+)
+```
+
+```ini
+#~/.config/hypr/hyprland Conf -> Lua guide
+MOD=hyde.config.modifiers.main
+_F = {description = "[Launcher|Apps] Demuestra layouts"}
+hl.bind(MOD .. " + ALT + L", hl.dsp.exec_cmd("hyde-shell layouts --select"), _F)
+```
+
+Start with HyDE's shipped modules for patterns that match the installed runtime, you could even restore the previous keybinds to your liking and mess about with the start_up as we'll see next up.
+
+### TOML still has a role
+
+TOML remains the data layer between scripting and runtime calls. `~/.config/hyde/config.toml` contains portable HyDE preferences such as desktop applications, startup commands and helpful aliases, while the installed schema describes valid fields. HyDE's configuration registry also uses TOML to describe editable files and their hooks, including `~/.config/hypr/hyprland.lua`.
+
+The separation:
+
++ Use **TOML** for HyDE options and schema-backed data.
++ Use **Lua** for Hyprland settings, bindings, rules, layouts, and event-driven behaviour.
++ Leave HyDE-managed files in `$XDG_DATA_HOME` alone unless you are developing HyDE itself.
+
+### What must be ported manually
+
+At minimum:
+
++ `keybindings.conf`
++ `windowrules.conf`
++ `monitors.conf`
++ `userprefs.conf`
+
+The Lua manifest intentionally conflicts with the legacy Hyprland manifest. Old files may remain on disk after a restore, but they are no longer the configuration source. Keep a backup until you have checked every bind, monitor, rule, and startup service in a new session.
+
+## Layouts and startup
+
+Use `hyde-shell layouts --select` to choose a shipped or custom layout.
+
+```text
+~/.config/hypr/lua/layouts/custom.lua
+```
+
+The old `[hyprland-start]` section has been replaced by `[desktop.start]` in `~/.config/hyde/config.toml`. Lua's `start_up.lua` runs these events in accordance to the local schema, when Hyprland emits its start event. The schema installed with HyDE documents the supported keys.
+
+### Restore and `deez`
+
+`deez` is HyDE's dotfile deployment backend in the Lua migration. It is normally an implementation detail: `./install.sh -r` uses the private executable in HyDE's Python environment to deploy the adequate manifests. Honestly, very litle manual intervention is needed in order to use the new dotfile client.
+
+If restore reports that `deez-dots` is missing, make sure your local `~/HyDE` folder is up-to-date, then
+prepare the environment quickly:
+
+```bash
+cd /path/to/HyDE/Scripts
+./install.sh -p
+./install.sh -r
+```
+
+For an intentionally controlled retry, use the same command shape as the installer, not an older `dot` subcommand:
+
+```bash
+"$HOME/.local/state/hyde/python_env/bin/deez" \
+  --source /path/to/HyDE \
+  --config /path/to/HyDE/Scripts/dots-groups/core.toml \
+  dots --skip-git --list
+```
+
+**Replace the `--list` flag for `--deploy all` only if you're sure it won't cause conflicts**
+If it does, please don't report on it. As mentioned `deez-dots` its an _implementation detail_,
+it's very practical outside our context but within, has been harnessed down so that there's very litte
+risk of it failing outside user error.
+
+:::tip[Use the full installer]
+Run `./install.sh -p` to establish environment setup according to the newest git pull of HyDE, and  `./install.sh -r` for a Lua restore. **Does not convert .conf -> .lua** It deploys both the core and extra manifests, restores theme state, and runs HyDE's follow-up steps. You can prioritize certain configurations in the `HyDE/Scripts/dots` directory so that they survive overwrites.
+:::
+
++ Old Hyprlang files and their Lua replacements
+
+```ini
+#This is the practical migration map, useful if you want to clean-up a migration:
+  -- ~/.config/hypr/hyprland.conf -> ~/.local/share/hypr/hyde.lua:1
+  -- ~/.config/hypr/keybindings.conf -> ~/.local/share/hypr/lua/key_binds.lua:1
+  -- ~/.config/hypr/userprefs.conf -> ~/.config/hypr/hyprland.lua:17
+  -- ~/.config/hypr/windowrules.conf, monitors.conf, nvidia.conf -> user hyprland.lua or a Lua module under lua/
+  -- ~/.config/hypr/animations.conf, workflows.conf -> Lua workflow/animation selectors, not the old conf files
+  -- ~/.local/share/hypr/_.conf and ~/.local/share/hyde/_.conf files -> mostly retired leftovers, kept only for migration/backups
+```
+
+## Migration checklist
+
+1. Review [Installation](../../getting-started/installation/) and clone the Lua-enabled HyDE revision you intend to use.
+2. Make a smart backup. I recommend: `~/.config/hypr`, `~/.config/hyde`, `~/.config/dconf`, `~/.config/gtk-3.0`, `~/.config/qt5ct`, `~/.config/qt6ct`, `~/.config/kdeglobals`, `~/.gtkrc-2.0`, and `~/.config/uwsm`.
+3. Definetly make sure `luarocks` and the preface is set-up: `./install.sh -p`. Running `./install.sh -r` will not and **can not** translsate or transfer your existing .conf syntax into usable HyDE+Lua syntax.
+4. Port legacy Hyprlang customisations into the directoris described throughout this doc. ($XDG_DATA_HOME, $HYPRLAND_CONFIG, $UWSM_FINALIZE_VARNAMES)
+5. Start a new HyDE session(should happen automatically), then verify the runtime and reload Hyprland:
+
+```bash
+printf 'mode: %s\nconfig: %s\nprofile: %s\n' \
+  "$HYDE_MODE" "$HYPRLAND_CONFIG" "$DCONF_PROFILE" "$HYDE_ACTIVATED" "$HYDE_FEATURE_LUA" "$QT_QPA_PLATFORM" &&
+test -f "$HYPRLAND_CONFIG" || read -r -p ans "Interupted, continue?(y/n)"
+test -z "$DCONF_PROFILE" || test -f "$DCONF_PROFILE"
+hyprctl reload
+```
+
+:::note[Need the legacy guide?]
+The current [Hyprland configuration](../../configuring/hyprland/) page remains the reference for a non-Lua HyDE installation. Do not mix its `.conf` examples with an active Lua runtime without first deciding which configuration stack your session is using.
+:::

--- a/src/content/docs/en/help/lua.md
+++ b/src/content/docs/en/help/lua.md
@@ -158,7 +158,7 @@ Start with HyDE's shipped modules for patterns that match the installed runtime,
 
 ### TOML still has a role
 
-TOML remains the data layer between scripting and runtime calls. `~/.config/hyde/config.toml` contains portable HyDE preferences such as desktop applications, startup commands and helpful aliases, while the installed schema describes valid fields. HyDE's configuration registry also uses TOML to describe editable files and their hooks, including `~/.config/hypr/hyprland.lua`.
+TOML remains the data layer between scripting and runtime calls. `$XDG_DATA_HOME/hyde/config-registry.toml` contains portable HyDE preferences such as desktop applications, startup commands and helpful aliases, while the installed schema describes valid fields. HyDE's configuration registry also uses TOML to describe editable files and their hooks, including `~/.config/hypr/hyprland.lua`.
 
 The separation:
 
@@ -185,7 +185,7 @@ Use `hyde-shell layouts --select` to choose a shipped or custom layout.
 ~/.config/hypr/lua/layouts/custom.lua
 ```
 
-The old `[hyprland-start]` section has been replaced by `[desktop.start]` in `~/.config/hyde/config.toml`. Lua's `start_up.lua` runs these events in accordance to the local schema, when Hyprland emits its start event. The schema installed with HyDE documents the supported keys.
+The old `[hyprland-start]` section has been replaced by `[desktop.start]` in `$XDG_DATA_HOME/hyde/schema/config.toml`. Lua's `start_up.lua` runs these events in accordance to the local schema, when Hyprland emits its start event. The schema installed with HyDE documents the supported keys.
 
 ### Restore and `deez`
 
@@ -227,7 +227,7 @@ Run `./install.sh -p` to establish environment setup according to the newest git
   -- ~/.config/hypr/userprefs.conf -> ~/.config/hypr/hyprland.lua:17
   -- ~/.config/hypr/windowrules.conf, monitors.conf, nvidia.conf -> user hyprland.lua or a Lua module under lua/
   -- ~/.config/hypr/animations.conf, workflows.conf -> Lua workflow/animation selectors, not the old conf files
-  -- ~/.local/share/hypr/_.conf and ~/.local/share/hyde/_.conf files -> mostly retired leftovers, kept only for migration/backups
+  -- ~/.local/share/hypr/_.conf and ~/.local/share/hyde/_.conf files -> mostly retired leftovers, kept only for migration/backups, the schema folder is useful to backup only if you have edited relevant startup instructions.
 ```
 
 ## Migration checklist
@@ -239,11 +239,43 @@ Run `./install.sh -p` to establish environment setup according to the newest git
 5. Start a new HyDE session(should happen automatically), then verify the runtime and reload Hyprland:
 
 ```bash
-printf 'mode: %s\nconfig: %s\nprofile: %s\n' \
-  "$HYDE_MODE" "$HYPRLAND_CONFIG" "$DCONF_PROFILE" "$HYDE_ACTIVATED" "$HYDE_FEATURE_LUA" "$QT_QPA_PLATFORM" &&
-test -f "$HYPRLAND_CONFIG" || read -r -p ans "Interupted, continue?(y/n)"
-test -z "$DCONF_PROFILE" || test -f "$DCONF_PROFILE"
-hyprctl reload
+sh -c '
+printf "%-18s %s\n" "HYDE_MODE"        "${HYDE_MODE:-<unset>}"
+printf "%-18s %s\n" "HYPRLAND_CONFIG"  "${HYPRLAND_CONFIG:-<unset>}"
+printf "%-18s %s\n" "DCONF_PROFILE"    "${DCONF_PROFILE:-<unset>}"
+printf "%-18s %s\n" "HYDE_ACTIVATED"   "${HYDE_ACTIVATED:-<unset>}"
+printf "%-18s %s\n" "HYDE_FEATURE_LUA" "${HYDE_FEATURE_LUA:-<unset>}"
+printf "%-18s %s\n" "QT_QPA_PLATFORM"  "${QT_QPA_PLATFORM:-<unset>}"
+echo
+need_p=0
+if command -v luarocks >/dev/null 2>&1; then
+    echo "luarocks: "
+else
+    echo "luarocks: not found"
+    need_p=1
+fi
+if [ -x "$HOME/.local/state/hyde/python_env/bin/deez" ]; then
+    echo "deez (python env): found"
+else
+    echo "deez (python env): not found"
+    need_p=1
+fi
+if [ -n "$HYPRLAND_CONFIG" ] && [ -f "$HYPRLAND_CONFIG" ]; then
+    echo "HYPRLAND_CONFIG: "
+else
+    echo "HYPRLAND_CONFIG: unset!"
+    exit 1
+fi
+if [ -n "$DCONF_PROFILE" ] && [ ! -f "$DCONF_PROFILE" ]; then
+    echo "warn: DCONF_PROFILE is set but the file itself is missing."
+fi
+echo
+if [ "$need_p" -eq 1 ]; then
+    echo "=> run ./install.sh -p before ./install.sh -r"
+else
+    echo "=> ./install.sh -p ran, safe to skip straight to -r"
+fi
+'
 ```
 
 :::note[Need the legacy guide?]

--- a/src/content/docs/en/help/lua.md
+++ b/src/content/docs/en/help/lua.md
@@ -2,7 +2,7 @@
 title: Lua for the User & Migration
 description: How HyDE's Lua-based Hyprland runtime is deployed, configured, and migrated from the legacy Hyprlang layout.
 sidebar:
-  order: 4
+order: 4
 ---
 
 This document explains the Lua-based Hyprland stack introduced by [the Lua migration](https://github.com/HyDE-Project/HyDE/discussions/1717). It is written for existing HyDE users deciding whether, and how, to move from the legacy Hyprlang configuration.

--- a/src/content/docs/es/help/lua.md
+++ b/src/content/docs/es/help/lua.md
@@ -1,8 +1,6 @@
 ---
 title: Runtime de Lua y migración
 description: Cómo se despliega, configura y migra el runtime de Hyprland basado en Lua de HyDE desde el layout heredado de Hyprlang.
-sidebar:
-order: 4
 ---
 
 Este documento explica el stack de Hyprland basado en Lua introducido por [la migración a Lua](https://github.com/HyDE-Project/HyDE/discussions/1717). Está escrito para usuarios existentes de HyDE que están decidiendo si migrar —y cómo hacerlo— desde la configuración heredada de Hyprlang.
@@ -20,7 +18,7 @@ En esencia, estamos migrando a algo con mejor soporte: **Lua**. Un lenguaje de s
 
 Hyprlang era el material antiguo que usábamos para transportar variables de entorno importantes, y su funcionalidad era limitada. Aquí un ejemplo tomado del antiguo startup.conf:
 
-```conf
+```sh
 exec-once = dbus-update-activation-environment --systemd --all #? Might fail so we hardcode the variables below
 exec-once = $start.DBUS_SHARE_PICKER    # dbus-update-activation-environment (one-time setup)
 exec-once = $start.SYSTEMD_SHARE_PICKER # systemctl --user import-environment (one-time setup)

--- a/src/content/docs/es/help/lua.md
+++ b/src/content/docs/es/help/lua.md
@@ -155,7 +155,7 @@ Empieza con los módulos que trae HyDE de fábrica para patrones que coincidan c
 
 ### TOML todavía tiene un papel
 
-TOML sigue siendo la capa de datos entre el scripting y las llamadas en runtime. `~/.config/hyde/config.toml` contiene preferencias portables de HyDE, como aplicaciones de escritorio, comandos de inicio y alias útiles, mientras que el esquema instalado describe los campos válidos. El registro de configuración de HyDE también usa TOML para describir los archivos editables y sus hooks, incluyendo `~/.config/hypr/hyprland.lua`.
+TOML sigue siendo la capa de datos entre el scripting y las llamadas en runtime. `$XDG_DATA_HOME/hyde/config-registry.toml` contiene preferencias portables de HyDE, como aplicaciones de escritorio, comandos de inicio y alias útiles, mientras que el esquema instalado describe los campos válidos. El registro de configuración de HyDE también usa TOML para describir los archivos editables y sus hooks, incluyendo `~/.config/hypr/hyprland.lua`.
 
 La separación:
 
@@ -182,7 +182,7 @@ Usa `hyde-shell layouts --select` para elegir un layout incluido de fábrica o u
 ~/.config/hypr/lua/layouts/custom.lua
 ```
 
-La antigua sección `[hyprland-start]` ha sido reemplazada por `[desktop.start]` en `~/.config/hyde/config.toml`. El `start_up.lua` de Lua ejecuta estos eventos de acuerdo con el esquema local, cuando Hyprland emite su evento de inicio. El esquema instalado con HyDE documenta las claves soportadas.
+La antigua sección `[hyprland-start]` ha sido reemplazada por `[desktop.start]` en `$XDG_DATA_HOME/hyde/schema/config.toml`. El `start_up.lua` de Lua ejecuta estos eventos de acuerdo con el esquema local, cuando Hyprland emite su evento de inicio. El esquema instalado con HyDE documenta las claves soportadas.
 
 ### Restauración y `deez`
 
@@ -221,9 +221,9 @@ Ejecuta `./install.sh -p` para establecer la configuración del entorno según e
   -- ~/.config/hypr/hyprland.conf -> ~/.local/share/hypr/hyde.lua:1
   -- ~/.config/hypr/keybindings.conf -> ~/.local/share/hypr/lua/key_binds.lua:1
   -- ~/.config/hypr/userprefs.conf -> ~/.config/hypr/hyprland.lua:17
-  -- ~/.config/hypr/windowrules.conf, monitors.conf, nvidia.conf -> user hyprland.lua or a Lua module under lua/
-  -- ~/.config/hypr/animations.conf, workflows.conf -> Lua workflow/animation selectors, not the old conf files
-  -- ~/.local/share/hypr/_.conf and ~/.local/share/hyde/_.conf files -> mostly retired leftovers, kept only for migration/backups
+  -- ~/.config/hypr/windowrules.conf, monitors.conf, nvidia.conf -> user hyprland.lua o un módulo de Lua bajo lua/
+  -- ~/.config/hypr/animations.conf, workflows.conf -> Lua workflow/animation selectors, no los archivos de conf antiguos
+  -- ~/.local/share/hypr/_.conf and ~/.local/share/hyde/_.conf files -> Sobras mantenidas para migraciones/respaldos, la carpeta de schema en partícular es solo útil respaldar si has editado las instrucciones relevantes de corrida.
 ```
 
 ## Lista de verificación de migración
@@ -235,11 +235,43 @@ Ejecuta `./install.sh -p` para establecer la configuración del entorno según e
 5. Inicia una nueva sesión de HyDE (debería ocurrir automáticamente), y luego verifica el runtime y recarga Hyprland:
 
 ```bash
-printf 'mode: %s\nconfig: %s\nprofile: %s\n' \
-  "$HYDE_MODE" "$HYPRLAND_CONFIG" "$DCONF_PROFILE" "$HYDE_ACTIVATED" "$HYDE_FEATURE_LUA" "$QT_QPA_PLATFORM" &&
-test -f "$HYPRLAND_CONFIG" || read -r -p ans "Interupted, continue?(y/n)"
-test -z "$DCONF_PROFILE" || test -f "$DCONF_PROFILE"
-hyprctl reload
+sh -c '
+printf "%-18s %s\n" "HYDE_MODE"        "${HYDE_MODE:-<unset>}"
+printf "%-18s %s\n" "HYPRLAND_CONFIG"  "${HYPRLAND_CONFIG:-<unset>}"
+printf "%-18s %s\n" "DCONF_PROFILE"    "${DCONF_PROFILE:-<unset>}"
+printf "%-18s %s\n" "HYDE_ACTIVATED"   "${HYDE_ACTIVATED:-<unset>}"
+printf "%-18s %s\n" "HYDE_FEATURE_LUA" "${HYDE_FEATURE_LUA:-<unset>}"
+printf "%-18s %s\n" "QT_QPA_PLATFORM"  "${QT_QPA_PLATFORM:-<unset>}"
+echo
+need_p=0
+if command -v luarocks >/dev/null 2>&1; then
+    echo "luarocks: "
+else
+    echo "luarocks: no encontrado"
+    need_p=1
+fi
+if [ -x "$HOME/.local/state/hyde/python_env/bin/deez" ]; then
+    echo "deez (python env): encontrado"
+else
+    echo "deez (python env): no encontrado "
+    need_p=1
+fi
+if [ -n "$HYPRLAND_CONFIG" ] && [ -f "$HYPRLAND_CONFIG" ]; then
+    echo "HYPRLAND_CONFIG: "
+else
+    echo "HYPRLAND_CONFIG: unset!"
+    exit 1
+fi
+if [ -n "$DCONF_PROFILE" ] && [ ! -f "$DCONF_PROFILE" ]; then
+    echo "Existe variable, falta el archivo."
+fi
+echo
+if [ "$need_p" -eq 1 ]; then
+    echo "=> corre ./install.sh -p antes de ./install.sh -r"
+else
+    echo "=> ./install.sh -p hecho, seguro para correr restauración -r"
+fi
+'
 ```
 
 :::note[¿Necesitas la guía heredada?]

--- a/src/content/docs/es/help/lua.md
+++ b/src/content/docs/es/help/lua.md
@@ -1,0 +1,247 @@
+---
+title: Runtime de Lua y migración
+description: Cómo se despliega, configura y migra el runtime de Hyprland basado en Lua de HyDE desde el layout heredado de Hyprlang.
+sidebar:
+  order: 4
+---
+
+Este documento explica el stack de Hyprland basado en Lua introducido por [la migración a Lua](https://github.com/HyDE-Project/HyDE/discussions/1717). Está escrito para usuarios existentes de HyDE que están decidiendo si migrar —y cómo hacerlo— desde la configuración heredada de Hyprlang.
+
+:::caution[Documentación de la era de migración]
+La migración a Lua modifica y elimina dot-files, así como directorios completos. Haz una copia de seguridad de tu configuración de Hyprland y HyDE antes de restaurar los dotfiles de Lua, solo si has editado los directorios de HyDE `.local/lib`, `.local/share`, `.local/state` o `.config/` (los drop-ins deberían sobrevivir). El artículo actual de [configuración de Hyprland](../../configuring/hyprland/) documenta el layout heredado en `.conf`; usa esta página como referencia complementaria de migración hasta que ese artículo se actualice.
+:::
+
+## De un vistazo 👁️‍🗨️
+
+HyDE no está reemplazando cada formato de configuración con Lua. Tampoco estamos forzando un refactor de cada script y componente.
+Se trata principalmente de longevidad: sellar el **runtime de Hyprland**, llevándolo de un árbol de `.conf` en Hyprlang hacia algo más estable.
+Además, la incorporación de módulos Lua y el mantener TOML para los ajustes declarativos de HyDE y los manifiestos de dotfiles encajan de forma natural.
+En esencia, estamos migrando a algo con mejor soporte: **Lua**. Un lenguaje de scripting y de sistemas bastante popular que, entre otras tareas, crea variables como `hl`, `start`, `hyde`, `hs`, etc. Esta es una mejora central:
+
+Hyprlang era el material antiguo que usábamos para transportar variables de entorno importantes, y su funcionalidad era limitada. Aquí un ejemplo tomado del antiguo startup.conf:
+
+```conf
+exec-once = dbus-update-activation-environment --systemd --all #? Might fail so we hardcode the variables below
+exec-once = $start.DBUS_SHARE_PICKER    # dbus-update-activation-environment (one-time setup)
+exec-once = $start.SYSTEMD_SHARE_PICKER # systemctl --user import-environment (one-time setup)
+exec-once = $start.XDG_PORTAL_RESET     # resetxdgportal.sh (one-time setup)
+```
+
+Como puedes ver, la infraestructura siempre fue algo desequilibrada en cuanto a viabilidad a largo plazo. En pocas palabras, Hyprlang era bueno para tener una tabla de variables, pero no para piezas en movimiento como las que requieren las operaciones en tiempo de ejecución (runtime).
+
+``` lua [.local/share/hypr/lua/start_up.lua]
+    hl.on(
+            "hyprland.start",
+            function()
+                check_exec(hs.dbus_share_picker)
+                check_exec(hs.systemd_share_picker)
+                check_exec(hs.auth_dialogue)
+    )
+```
+
+En lugar de esperar que `startup.conf` se dispare antes de que Hyprland inicie, declaramos un evento `hyprland.start` o `hyde.activate` que se encadena hacia la operación en runtime; `hyde-shell reload` lo demuestra al reconstruir los entornos principales.
+
+## Layouts
+
+Layouts es una función nueva y exclusiva de Lua que permite al usuario cambiar el comportamiento de todo su WM en una sola acción rápida: keybinds, transiciones entre espacios de trabajo y ventanas, además de la sensación (_feel_) general de tu equipo.
+El flujo de trabajo y los ajustes de layout predeterminados no están configurados por defecto, lo que significa que algo más tiene que activarlos.
+
+Elige un layout:
+
+```sh
+hyde-shell layouts --select
+```
+
+### Archivos y aspectos destacados
+
+| Aspecto | Configuración heredada | Configuración en Lua |
+| --- | --- | --- |
+| Punto de entrada de Hyprland | `~/.config/hypr/hyprland.conf` o `$XDG_DATA_HOME/hyprland.conf` | `$XDG_DATA_HOME/hypr/hyde.lua` y `~/.config/hypr/hyprland.lua` |
+| Reglas de ventana | `~/.config/hypr/windowrules.conf` | `/.local/share/hypr/lua/window_rules.lua`, aunque preferiblemente deberías migrarlas a `hyprland.lua` |
+| Ajustes de inicio | `[hyprland-start]` en `config.toml` | `[desktop.start]` en `$XDG_DATA_HOME/hyde/config-registry.toml` |
+| Preferencias de usuario (UserPrefs) | `.config/hypr/userprefs.conf` | `~/.local/share/hypr/lua/defaults.lua` |
+| Copia de seguridad y restauración | [listas de restauración heredadas](../resources/restore.md) | [manifiestos de `deez` invocados por `install.sh -r`](../resources/restore.md##tomlConfiguration) |
+
+:::tip[HyDE+Lua trae un límite de módulos completamente nuevo]
+Si estás acostumbrado a editar archivos conf debido a temas con bugs visuales o actualizaciones mal sincronizadas, te va a encantar la nueva rigidez de Lua; y si nunca has tenido que lidiar con eso, considéralo el momento perfecto para sumarte y ayudar a mejorar HyDE.
+:::
+
+Lua evita muchos de los trucos puntuales que empezamos a usar para lograr que Hyprlang funcionara en rutinas más finas, pero **no** es una mejora de rendimiento garantizada. Su principal beneficio es una configuración más mantenible y soporte a largo plazo. La siguiente tabla toma los 'cambios' como las diferencias entre la última rama de desarrollo disponible y una versión 'estable' anterior al 12 de mayo de 2026 [95adf01]:
+
+| Archivos modificados | | Cambios de LOC | Scripts | Descripción |
+| --- | --- | --- | --- | --- |
+| 44 | +2,074 | −159 | 33 añadidos, 11 modificados, 29 sin cambios | Añade manifiestos y migraciones de dotfiles; actualiza el soporte de instalación y restauración. |
+
+las nuevas carpetas `dots` y `dots-groups` en ~/HyDE/Scripts/ que contienen los esquemas de dotfiles.
+
+`Funciones auxiliares` para `install.sh` que se supone hacen la migración más simple y refuerzan el entorno de Python.
+_~/HyDE/Scripts/dots/hyprland.toml_ despliega el árbol de Lua.
+
+Todos los puntos de entrada anteriores han sido actualizados;
+
+| Punto de entrada | Descripción |
+| --- | --- |
+| $XDG_DATA_HOME/.local/share/hypr/hyde.lua | Cumple promesas hacia el entorno, tales como el entorno de runtime, los scripts principales de Lua, todas las preferencias de usuario en `.config/` y los fallbacks de `.local/` |
+| $XDG_CONFIG_HOME/hypr/hyprland.lua | Capa de sobrescritura del usuario, o simplemente 'preferencias de usuario'; forma parte de la zona deseada para interactuar con esta actualización, desde añadir keybinds hasta invocar scripts de HyDE con Lua. La directiva `require("")` es de mucha ayuda |
+
+---
+
+:::danger
+No toques datos de TOML o Lua que no reconozcas: el costo de tener una configuración de dotfiles rota es mucho mayor, al igual que lo es nuestra capacidad de seguir construyendo HyDE. $XDG_DATA_HOME/hypr/lua/* define gran parte de lo que ocurre después de que uwsm inicia y monta la configuración drop-in de HyDE, y está en el corazón de la funcionalidad de HyDE.
+:::
+
+### Actualizaciones de runtime
+
+Dado que Lua ahora corre en paralelo respecto a nuestro entorno de Python, HyDE activa el stack de Lua a través de UWSM:
+
+```text
+UWSM environment scripts
+  -> ~/.local/lib/hyde/shell/activate
+  -> HYDE_MODE=lua and HYPRLAND_CONFIG=.../hypr/hyde.lua
+  -> Hyprland loads hyde.lua
+  -> HyDE loads its Lua modules and ~/.config/hypr/hyprland.lua
+```
+
+El runtime compartido vive bajo `$XDG_DATA_HOME/hypr/`; tus cambios de usuario van bajo `$XDG_CONFIG_HOME/hypr/`. Esto sigue la separación habitual de HyDE entre datos mantenidos por el proyecto y configuración propiedad del usuario. Consulta [Secretos y Portales](../secrets/) para el modelo de sesión de UWSM y XDG relacionado.
+
+:::note[No edites el runtime compartido sin una razón]
+Los archivos bajo `~/.local/share/hypr/lua/` y `~/.local/share/hypr/hyde.lua` son desplegados por HyDE y pueden cambiar en cada restauración. Diversifica colocando tus sobrescrituras directas en `~/.config/hypr/hyprland.lua`, y divide las personalizaciones más grandes en archivos Lua que puedan cargarse después con `require()`.
+:::
+
+## De Hyprlang a Lua
+
+**Los archivos de Hyprlang son declarativos**: describen ajustes y despachan comandos. Lo que había dentro de un archivo .conf era, en cierto modo, una mentira: siempre fue y tenderá a ser sintaxis compatible con `Hypr`. Lua puede expresar los mismos ajustes, y además añadir funciones, manejadores de eventos y helpers compartidos donde tenga sentido; algo que, de todas formas, ya hacían algunos archivos conf.
+
+Por ejemplo, un bloque de input heredado como el siguiente:
+
+```ini
+# ~/.config/hypr/userprefs.conf
+input {
+    kb_layout = us,es
+    accel_profile = flat
+}
+```
+
+se convierte en un perfil más expresivo:
+
+```lua
+# ~/.config/hypr/hyprland.lua
+hl.config({
+    input = {
+        kb_layout = "us,es",
+        accel_profile = "flat",
+    },
+})
+```
+
+De igual forma, un keybind puede usar los helpers de Lua de HyDE en lugar de una línea `bind` delimitada por comas:
+
+```lua
+hl.bind(
+    "SUPER + Q",
+    hl.dsp.window.close(),
+    { description = "[Window Management] close focused window" }
+)
+```
+
+```ini
+#~/.config/hypr/hyprland Conf -> Lua guide
+MOD=hyde.config.modifiers.main
+_F = {description = "[Launcher|Apps] Demuestra layouts"}
+hl.bind(MOD .. " + ALT + L", hl.dsp.exec_cmd("hyde-shell layouts --select"), _F)
+```
+
+Empieza con los módulos que trae HyDE de fábrica para patrones que coincidan con el runtime instalado; incluso podrías restaurar tus keybinds anteriores a tu gusto y experimentar con el start_up, como veremos a continuación.
+
+### TOML todavía tiene un papel
+
+TOML sigue siendo la capa de datos entre el scripting y las llamadas en runtime. `~/.config/hyde/config.toml` contiene preferencias portables de HyDE, como aplicaciones de escritorio, comandos de inicio y alias útiles, mientras que el esquema instalado describe los campos válidos. El registro de configuración de HyDE también usa TOML para describir los archivos editables y sus hooks, incluyendo `~/.config/hypr/hyprland.lua`.
+
+La separación:
+
++ Usa **TOML** para las opciones de HyDE y datos respaldados por un esquema.
++ Usa **Lua** para los ajustes, bindings, reglas, layouts y comportamiento orientado a eventos de Hyprland.
++ No toques los archivos gestionados por HyDE en `$XDG_DATA_HOME`, a menos que estés desarrollando el propio HyDE.
+
+### Qué debe migrarse manualmente
+
+Como mínimo:
+
++ `keybindings.conf`
++ `windowrules.conf`
++ `monitors.conf`
++ `userprefs.conf`
+
+El manifiesto de Lua entra en conflicto de forma intencional con el manifiesto heredado de Hyprland. Los archivos antiguos pueden permanecer en disco después de una restauración, pero ya no son la fuente de configuración. Conserva una copia de seguridad hasta que hayas revisado cada bind, monitor, regla y servicio de inicio en una sesión nueva.
+
+## Layouts e inicio
+
+Usa `hyde-shell layouts --select` para elegir un layout incluido de fábrica o uno personalizado.
+
+```text
+~/.config/hypr/lua/layouts/custom.lua
+```
+
+La antigua sección `[hyprland-start]` ha sido reemplazada por `[desktop.start]` en `~/.config/hyde/config.toml`. El `start_up.lua` de Lua ejecuta estos eventos de acuerdo con el esquema local, cuando Hyprland emite su evento de inicio. El esquema instalado con HyDE documenta las claves soportadas.
+
+### Restauración y `deez`
+
+`deez` es el backend de despliegue de dotfiles de HyDE dentro de la migración a Lua. Normalmente es un detalle de implementación: `./install.sh -r` usa el ejecutable privado dentro del entorno de Python de HyDE para desplegar los manifiestos adecuados. Honestamente, se necesita muy poca intervención manual para usar el nuevo cliente de dotfiles.
+
+Si la restauración reporta que falta `deez-dots`, asegúrate de que tu carpeta local `~/HyDE` esté actualizada, y luego prepara el entorno rápidamente:
+
+```bash
+cd /path/to/HyDE/Scripts
+./install.sh -p
+./install.sh -r
+```
+
+Para un reintento intencionalmente controlado, usa la misma forma de comando que el instalador, no un subcomando `dot` más antiguo:
+
+```bash
+"$HOME/.local/state/hyde/python_env/bin/deez" \
+  --source /path/to/HyDE \
+  --config /path/to/HyDE/Scripts/dots-groups/core.toml \
+  dots --skip-git --list
+```
+
+**Reemplaza la bandera `--list` por `--deploy all` solo si estás seguro de que no causará conflictos.**
+Si lo hace, por favor no lo reportes. Como se mencionó, `deez-dots` es un _detalle de implementación_;
+es muy práctico fuera de nuestro contexto, pero dentro de él ha sido restringido de forma que exista muy poco
+riesgo de que falle fuera de un error del usuario.
+
+:::tip[Usa el instalador completo]
+Ejecuta `./install.sh -p` para establecer la configuración del entorno según el último `git pull` de HyDE, y `./install.sh -r` para una restauración de Lua. **No convierte .conf -> .lua.** Despliega tanto los manifiestos principales como los adicionales, restaura el estado del tema y ejecuta los pasos posteriores de HyDE. Puedes priorizar ciertas configuraciones dentro del directorio `HyDE/Scripts/dots` para que sobrevivan a las sobrescrituras.
+:::
+
++ Archivos antiguos de Hyprlang y sus reemplazos en Lua
+
+```ini
+#Este es el mapa práctico de migración, útil si quieres limpiar una migración:
+  -- ~/.config/hypr/hyprland.conf -> ~/.local/share/hypr/hyde.lua:1
+  -- ~/.config/hypr/keybindings.conf -> ~/.local/share/hypr/lua/key_binds.lua:1
+  -- ~/.config/hypr/userprefs.conf -> ~/.config/hypr/hyprland.lua:17
+  -- ~/.config/hypr/windowrules.conf, monitors.conf, nvidia.conf -> user hyprland.lua or a Lua module under lua/
+  -- ~/.config/hypr/animations.conf, workflows.conf -> Lua workflow/animation selectors, not the old conf files
+  -- ~/.local/share/hypr/_.conf and ~/.local/share/hyde/_.conf files -> mostly retired leftovers, kept only for migration/backups
+```
+
+## Lista de verificación de migración
+
+1. Revisa la [Instalación](../../getting-started/installation/) y clona la revisión de HyDE con soporte para Lua que planeas usar.
+2. Haz una copia de seguridad inteligente. Recomiendo: `~/.config/hypr`, `~/.config/hyde`, `~/.config/dconf`, `~/.config/gtk-3.0`, `~/.config/qt5ct`, `~/.config/qt6ct`, `~/.config/kdeglobals`, `~/.gtkrc-2.0`, y `~/.config/uwsm`.
+3. Asegúrate definitivamente de tener `luarocks` y el preface configurados con: `./install.sh -p`. Ejecutar `./install.sh -r` no va a **ni puede** traducir o transferir tu sintaxis .conf existente a una sintaxis utilizable de HyDE+Lua.
+4. Migra tus personalizaciones heredadas de Hyprlang a los directorios descritos a lo largo de este documento. ($XDG_DATA_HOME, $HYPRLAND_CONFIG, $UWSM_FINALIZE_VARNAMES)
+5. Inicia una nueva sesión de HyDE (debería ocurrir automáticamente), y luego verifica el runtime y recarga Hyprland:
+
+```bash
+printf 'mode: %s\nconfig: %s\nprofile: %s\n' \
+  "$HYDE_MODE" "$HYPRLAND_CONFIG" "$DCONF_PROFILE" "$HYDE_ACTIVATED" "$HYDE_FEATURE_LUA" "$QT_QPA_PLATFORM" &&
+test -f "$HYPRLAND_CONFIG" || read -r -p ans "Interupted, continue?(y/n)"
+test -z "$DCONF_PROFILE" || test -f "$DCONF_PROFILE"
+hyprctl reload
+```
+
+:::note[¿Necesitas la guía heredada?]
+La página actual de [configuración de Hyprland](../../configuring/hyprland/) sigue siendo la referencia para una instalación de HyDE sin Lua. No mezcles sus ejemplos en `.conf` con un runtime de Lua activo sin antes decidir qué stack de configuración está usando tu sesión.
+:::

--- a/src/content/docs/es/help/lua.md
+++ b/src/content/docs/es/help/lua.md
@@ -60,7 +60,7 @@ hyde-shell layouts --select
 | Reglas de ventana | `~/.config/hypr/windowrules.conf` | `/.local/share/hypr/lua/window_rules.lua`, aunque preferiblemente deberías migrarlas a `hyprland.lua` |
 | Ajustes de inicio | `[hyprland-start]` en `config.toml` | `[desktop.start]` en `$XDG_DATA_HOME/hyde/config-registry.toml` |
 | Preferencias de usuario (UserPrefs) | `.config/hypr/userprefs.conf` | `~/.local/share/hypr/lua/defaults.lua` |
-| Copia de seguridad y restauración | [listas de restauración heredadas](../resources/restore.md) | [manifiestos de `deez` invocados por `install.sh -r`](../resources/restore.md##tomlConfiguration) |
+| Copia de seguridad y restauración | [listas de restauración heredadas](../resources/restore.md) | [manifiestos de `deez` invocados por `install.sh -r`](../resources/restore.md#tomlConfiguration) |
 
 :::tip[HyDE+Lua trae un límite de módulos completamente nuevo]
 Si estás acostumbrado a editar archivos conf debido a temas con bugs visuales o actualizaciones mal sincronizadas, te va a encantar la nueva rigidez de Lua; y si nunca has tenido que lidiar con eso, considéralo el momento perfecto para sumarte y ayudar a mejorar HyDE.
@@ -70,7 +70,7 @@ Lua evita muchos de los trucos puntuales que empezamos a usar para lograr que Hy
 
 | Archivos modificados | | Cambios de LOC | Scripts | Descripción |
 | --- | --- | --- | --- | --- |
-| 44 | +2,074 | −159 | 33 añadidos, 11 modificados, 29 sin cambios | Añade manifiestos y migraciones de dotfiles; actualiza el soporte de instalación y restauración. |
+| 44 | +2,074, | −159 | 33 añadidos, 11 modificados, 29 sin cambios | Añade manifiestos y migraciones de dotfiles; actualiza el soporte de instalación y restauración. |
 
 las nuevas carpetas `dots` y `dots-groups` en ~/HyDE/Scripts/ que contienen los esquemas de dotfiles.
 

--- a/src/content/docs/es/help/lua.md
+++ b/src/content/docs/es/help/lua.md
@@ -2,7 +2,7 @@
 title: Runtime de Lua y migración
 description: Cómo se despliega, configura y migra el runtime de Hyprland basado en Lua de HyDE desde el layout heredado de Hyprlang.
 sidebar:
-  order: 4
+order: 4
 ---
 
 Este documento explica el stack de Hyprland basado en Lua introducido por [la migración a Lua](https://github.com/HyDE-Project/HyDE/discussions/1717). Está escrito para usuarios existentes de HyDE que están decidiendo si migrar —y cómo hacerlo— desde la configuración heredada de Hyprlang.


### PR DESCRIPTION
This pull request is intended for the wiki only, I may or may not also update the /resources/restore and  /configuring/hyprland/ articles along-side the faq. It is key we implement this article as the install stack and lua migration near a turning point that requires some explanation from now until forever in my honest opinon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Spanish guides for migrating to and using HyDE’s Lua-based runtime.
  * Documented configuration layouts, startup events, TOML and Lua responsibilities, user overrides, restoration workflows, and verification steps.
  * Added migration guidance for legacy configuration files, including manual conversion requirements.
  * Included warnings about backups, managed files, and legacy configuration compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->